### PR TITLE
Remove path & method from httpRequestDuraction

### DIFF
--- a/lib/models/prometheus/prometheusMiddlewares.js
+++ b/lib/models/prometheus/prometheusMiddlewares.js
@@ -6,43 +6,7 @@ const config = require('../../config');
 const register = require('./register');
 
 
-function getPath (ctx) {
-    let path = ctx.req.url;
-    if (ctx.matched && ctx.matched.length) {
-        path = ctx.matched[0].path; // eslint-disable-line prefer-destructuring
-    }
-    return path;
-}
-
 module.exports = {
-
-    /**
-     * {{
-     *  appName: String
-     * }} options
-     * @returns {function}
-     * @deprecated
-     */
-    getHttpRequestMetricsMiddleware (options) {
-
-        const metrics = new promClient.Counter({
-            name: 'httpRequest',
-            help: 'Request rate tracking',
-            labelNames: ['name', 'query', 'status', 'message', 'originalUrl'],
-            registers: [register]
-        });
-
-        return async (ctx, next) => {
-            await next();
-            metrics.inc({
-                name: options.appName,
-                status: ctx.response.status,
-                method: ctx.request.method,
-                path: getPath(ctx),
-                env: config.env || null
-            });
-        };
-    },
 
     /**
      * {{
@@ -55,20 +19,18 @@ module.exports = {
         const histogram = new promClient.Histogram({
             name: 'httpRequestDuration',
             help: 'Requests duration tracking',
-            labelNames: ['name', 'method', 'env', 'path', 'status'],
+            labelNames: ['name', 'env', 'status'],
             registers: [register]
         });
 
         return async (ctx, next) => {
             const end = histogram.startTimer({
                 name: options.appName,
-                method: ctx.request.method,
                 env: config.env || null
             });
             await next();
             end({
-                status: ctx.response.status,
-                path: getPath(ctx)
+                status: ctx.response.status
             });
         };
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storyous/common-utils",
-  "version": "5.4.0",
+  "version": "6.0.0",
   "description": "Common utils for storyous microservices",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
when collecting httpRequestDuration metric with path & request tag is creating circa 300 000 unique metric collections. We don't use this data fro now, so there is no reason to collect this detailed data.

 + remove deprecated httpRequest middleware