### PR TITLE
etag calculation

### DIFF
--- a/lib/getMongoCachedJSONFetcher.js
+++ b/lib/getMongoCachedJSONFetcher.js
@@ -132,7 +132,7 @@ const getKeyResolver = (cacheConfig, key, url) => {
 
             const timeoutId = setTimeout(() => {
                 cacheConfig.logError(new Error('Loading of the content timed out.'));
-                findRecord(cacheConfig.collection, key)
+                findRecord(cacheConfig.collection, key, metaProjection)
                     .then((record) => {
                         if (!record) {
                             throw new Error('Cache refresh timed-out and there is no cached version to serve yet.');

--- a/lib/getMongoCachedJSONFetcher.js
+++ b/lib/getMongoCachedJSONFetcher.js
@@ -79,10 +79,10 @@ const getKeyResolver = (cacheConfig, key, url) => {
 
         const freshnessLimitDate = new Date(Date.now() - cacheConfig.cacheLifetime);
 
-        const refreshPromise = (async () => {
+        // find meta only, we don't want to hold potentially large data in memory during the fetch
+        const meta = await findRecord(cacheConfig.collection, key, metaProjection);
 
-            // find meta only, we don't want to hold potentially large data in memory during the fetch
-            const meta = await findRecord(cacheConfig.collection, key, metaProjection);
+        const refreshPromise = (async () => {
 
             if (meta && isCacheFresh(meta.fetchedAt, freshnessLimitDate)) {
                 return meta;
@@ -132,14 +132,10 @@ const getKeyResolver = (cacheConfig, key, url) => {
 
             const timeoutId = setTimeout(() => {
                 cacheConfig.logError(new Error('Loading of the content timed out.'));
-                findRecord(cacheConfig.collection, key, metaProjection)
-                    .then((record) => {
-                        if (!record) {
-                            throw new Error('Cache refresh timed-out and there is no cached version to serve yet.');
-                        }
-                        return record;
-                    })
-                    .then(resolve, reject);
+                if (!meta) {
+                    reject(new Error('Cache refresh timed-out and there is no cached version to serve yet.'));
+                }
+                resolve(meta);
             }, cacheConfig.timeout);
 
             refreshPromise

--- a/lib/getMongoCachedJSONFetcher.js
+++ b/lib/getMongoCachedJSONFetcher.js
@@ -4,8 +4,15 @@ const fetch = require('node-fetch');
 const { Collection } = require('mongodb');
 const assert = require('assert');
 const { cloneDeep, once } = require('lodash');
+const crypto = require('crypto');
 const AppError = require('./appError');
 
+const calculateETagByText = (responseText) => {
+    // sha1-base64 is the fastest
+    // see https://medium.com/@chris_72272/what-is-the-fastest-node-js-hashing-algorithm-c15c1a0e164e
+    const hash = crypto.createHash('sha1').update(responseText).digest('base64');
+    return `W/"${hash}"`;
+};
 
 const doFetch = async (jsonUrl, etag, options) => {
 
@@ -22,8 +29,6 @@ const doFetch = async (jsonUrl, etag, options) => {
 
     const response = await fetch(jsonUrl, fetchOptions);
 
-    const notModified = etag && response.status === 304;
-
     if (!response.ok && response.status !== 304) {
         throw AppError.internal(`URL fetch fail: ${jsonUrl}`, {
             response: {
@@ -33,10 +38,16 @@ const doFetch = async (jsonUrl, etag, options) => {
         });
     }
 
+    const responseText = await response.text();
+
+    const newEtag = response.headers.get('etag') || calculateETagByText(responseText);
+
+    const notModified = etag && (response.status === 304 || etag === newEtag);
+
     return {
         notModified,
-        newEtag: response.headers.get('etag') || null,
-        newContent: notModified ? null : await response.json()
+        newEtag,
+        newContent: notModified ? null : JSON.parse(responseText)
     };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@storyous/common-utils",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storyous/common-utils",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Common utils for storyous microservices",
   "main": "lib/index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ const parameters = {
 const {
     content, // file content, null in case of etagMatch=true
     isCacheFresh, // boolean saying the content is not after its lifetime
-    etag, // entity tag (version). It's null if the remote source didn't provide it in the last 200 response, it can be used in future fetcher calls as ifNoneMatch parameter
+    etag, // entity tag (version). If not null, it can be used in future fetcher calls as ifNoneMatch parameter
     etagMatch // boolean, truthy if isNoneMatch parameter provided and corresponds with latest cached etag value
 } = await fetcher(parameters /* optional */ );
 ```


### PR DESCRIPTION
etag is automatically calculated if remote server does not support it, pros: lower database load when the content is not changed, content can be effectively cached by fetch consumers even the original resource does not provide the etag